### PR TITLE
Async dma driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
 
 jobs:
   build_examples:
-    name: Build examples
+    name: Build
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-D warnings"
@@ -21,6 +21,23 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabihf
+
+      - name: Build
+        run: cargo +stable build --all-features
+
+  build_examples:
+    name: Build examples
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: thumbv7em-none-eabihf
 
@@ -36,8 +53,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: thumbv7em-none-eabihf
 
@@ -70,17 +87,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
           targets: thumbv7em-none-eabihf
 
       - name: Run cargo fmt
-        run: cargo +stable fmt --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo +stable clippy --all-features --examples -- -D warnings
+        run: cargo clippy --all-features --examples -- -D warnings
 
   docs:
     name: Documentation
@@ -89,15 +106,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: thumbv7em-none-eabihf
 
       - name: Run cargo doc
         env:
           RUSTDOCFLAGS: "-Dwarnings"
-        run: cargo +stable doc --no-deps --examples
+        run: cargo doc --no-deps --examples
 
   release:
     name: Publish version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: sed -i '/harness = false/c\#harness = false' Cargo.toml
 
       - name: Run tests
-        run: cargo test --lib --all-features --target=x86_64-unknown-linux-gnu
+        run: cargo +stable test --lib --all-features --target=x86_64-unknown-linux-gnu
 
   lints:
     name: Lints
@@ -77,10 +77,10 @@ jobs:
           targets: thumbv7em-none-eabihf
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo +stable fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy --all-features --examples -- -D warnings
+        run: cargo +stable clippy --all-features --examples -- -D warnings
 
   docs:
     name: Documentation
@@ -97,7 +97,7 @@ jobs:
       - name: Run cargo doc
         env:
           RUSTDOCFLAGS: "-Dwarnings"
-        run: cargo doc --no-deps --examples
+        run: cargo +stable doc --no-deps --examples
 
   release:
     name: Publish version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 name: CI
 
 jobs:
-  build_examples:
+  build:
     name: Build
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: thumbv7em-none-eabihf
+
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -94,7 +100,7 @@ jobs:
           targets: thumbv7em-none-eabihf
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo +stable fmt --all -- --check
 
       - name: Run cargo clippy
         run: cargo clippy --all-features --examples -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ futures = { version = "0.3.29", default-features = false, features = [
     "async-await",
 ] }
 
-# Semaphore
-rtic-common = "1.0.0"
-
 [dev-dependencies]
 
 rtic = { version = "2.0.1", features = ["thumbv7-backend"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws2812-flexio"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Finomnis <finomnis@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,8 @@ futures = { version = "0.3.29", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-
-rtic = { version = "2.0.1", features = ["thumbv7-backend"] }
-
 embedded-hal = "0.2.7"
+rtic = { version = "2.0.1", features = ["thumbv7-backend"] }
 
 # Board support package
 teensy4-bsp = { version = "0.4.3", features = ["rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,15 @@ cassette = "0.2.3"
 
 # Additional CI dependencies
 teensy4-bsp = { version = "0.4", optional = true }
+futures = { version = "0.3.29", default-features = false, features = [
+    "async-await",
+] }
 
 
 [dev-dependencies]
+
+rtic = { version = "2.0.1", features = ["thumbv7-backend"] }
+
 cortex-m = "0.7.7"
 embedded-hal = "0.2.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ github_ci = ["teensy4-bsp"]
 [dependencies]
 imxrt-hal = "0.5.3"
 imxrt-ral = "0.5.1"
+cortex-m = "0.7.7"
 log = "0.4.19"
 paste = "1.0.12"
 snafu = { version = "0.7.4", default-features = false }
@@ -38,19 +39,17 @@ futures = { version = "0.3.29", default-features = false, features = [
     "async-await",
 ] }
 
+# Semaphore
+rtic-common = "1.0.0"
 
 [dev-dependencies]
 
 rtic = { version = "2.0.1", features = ["thumbv7-backend"] }
 
-cortex-m = "0.7.7"
 embedded-hal = "0.2.7"
 
 # Board support package
 teensy4-bsp = { version = "0.4.3", features = ["rt"] }
-
-# Logging
-critical-section = "1.1.1"
 
 # Packages necessary for board usage
 nb = "1.1.0"    # Async

--- a/examples/common/uart/uart_log.rs
+++ b/examples/common/uart/uart_log.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use critical_section::Mutex;
+use cortex_m::interrupt::{self, Mutex};
 use log::{LevelFilter, Log};
 use teensy4_bsp::board::Lpuart6;
 
@@ -19,7 +19,7 @@ pub fn init(uart: UartWriter<Lpuart6>, max_level: LevelFilter) {
         let logger = unsafe { LOGGER.insert(UartLogger::new(uart)) };
 
         if let Err(e) = log::set_logger(logger) {
-            critical_section::with(|cs| {
+            interrupt::free(|cs| {
                 writeln!(
                     logger.uart.borrow(cs).borrow_mut(),
                     "Unable to set logger: {}",
@@ -50,7 +50,7 @@ impl Log for UartLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        critical_section::with(|cs| {
+        interrupt::free(|cs| {
             let mut uart = self.uart.borrow(cs).borrow_mut();
             let color = match record.level() {
                 log::Level::Error => "31",

--- a/examples/triple_332_dma_blocking.rs
+++ b/examples/triple_332_dma_blocking.rs
@@ -140,7 +140,7 @@ fn main() -> ! {
         flip_buffers = !flip_buffers;
 
         let lagged = neopixel
-            .write_dma(display_buffer, &mut neopixel_dma, 1, || {
+            .write_dma_blocking(display_buffer, &mut neopixel_dma, 1, || {
                 t += 1;
 
                 render_frame(

--- a/examples/triple_332_dma_rtic.rs
+++ b/examples/triple_332_dma_rtic.rs
@@ -1,0 +1,228 @@
+// This example renders a moving rainbow on a 332 pixel long led strip using a Teensy MicroMod.
+//
+// Led Strip: https://www.ipixelleds.com/index.php?id=923
+// Teensy Micromod: https://www.sparkfun.com/products/16402
+//
+// The Teensy Micromod is based on the imxrt-1062 MCU.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)] // Required for RTIC 2.0 right now
+
+use teensy4_bsp as bsp;
+
+use bsp::board;
+use bsp::hal;
+use bsp::ral;
+
+mod common;
+use common::{
+    effects,
+    uart::{uart_log, UartWriter},
+};
+
+use palette::LinSrgb;
+use palette::Srgb;
+
+use ws2812_flexio::{IntoPixelStream, PreprocessedPixels, WS2812Driver};
+
+const NUM_PIXELS: usize = 332;
+
+fn linearize_color(col: &Srgb) -> LinSrgb<u8> {
+    col.into_linear().into_format()
+}
+
+fn render_frame(
+    t: u32,
+    framebuffer_0: &mut [Srgb],
+    framebuffer_1: &mut [Srgb],
+    framebuffer_2: &mut [[u8; 3]],
+    render_buffer: &mut PreprocessedPixels<NUM_PIXELS, 3>,
+) {
+    effects::running_dots(t, framebuffer_0);
+    effects::rainbow(t, framebuffer_1);
+    effects::test_pattern(framebuffer_2);
+
+    render_buffer.prepare_pixels([
+        &mut framebuffer_0
+            .iter()
+            .map(linearize_color)
+            .into_pixel_stream(),
+        &mut framebuffer_1
+            .iter()
+            .map(linearize_color)
+            .into_pixel_stream(),
+        &mut framebuffer_2.into_pixel_stream(),
+    ]);
+}
+
+#[rtic::app(device = teensy4_bsp, dispatchers = [LPSPI1])]
+mod app {
+    use bsp::pins::common::{P6, P7, P8};
+
+    use super::*;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        led: board::Led,
+        us_timer: hal::gpt::Gpt1,
+        neopixel: WS2812Driver<2, 3, (P6, P7, P8)>,
+        neopixel_dma: hal::dma::channel::Channel,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let board::Resources {
+            mut gpio2,
+            pins,
+            lpuart6,
+            gpt1: mut us_timer,
+            ccm,
+            flexio2,
+            mut dma,
+            ..
+        } = board::t40(cx.device);
+
+        // Initialize LED
+        let led = board::led(&mut gpio2, pins.p13);
+        led.set();
+
+        // Initialize UART
+        let mut uart = UartWriter::new(board::lpuart(lpuart6, pins.p1, pins.p0, 115200));
+        writeln!(uart);
+
+        // Write welcome message
+        writeln!(uart, "===== WS2812 Rainbow Example (with DMA!) =====");
+        writeln!(uart);
+
+        // Initialize logging
+        uart_log::init(uart, log::LevelFilter::Debug);
+
+        // Initialize timer
+        // Is a 32-bit timer with us precision.
+        // Overflows every 71.58 minutes, which is sufficient for our example.
+        log::info!("Initializing timer ...");
+        assert_eq!(board::PERCLK_FREQUENCY, 1_000_000);
+        us_timer.set_clock_source(hal::gpt::ClockSource::PeripheralClock);
+        us_timer.set_divider(1);
+        us_timer.set_mode(hal::gpt::Mode::FreeRunning);
+        us_timer.enable();
+        log::debug!("Timer initialized.");
+
+        // Initialize DMA
+        let neopixel_dma = dma[0].take().unwrap();
+
+        // Ws2812 driver
+        log::info!("Initializing FlexIO ...");
+        // Set FlexIO clock to 16Mhz, as required by the driver
+        ral::modify_reg!(
+            ral::ccm,
+            ccm,
+            CS1CDR,
+            FLEXIO2_CLK_PRED: FLEXIO2_CLK_PRED_4,
+            FLEXIO2_CLK_PODF: DIVIDE_6,
+        );
+        let neopixel = WS2812Driver::init(flexio2, (pins.p6, pins.p7, pins.p8)).unwrap();
+        log::debug!("FlexIO initialized.");
+
+        // Spawn animation task
+        animate::spawn().unwrap();
+
+        (
+            Shared {},
+            Local {
+                led,
+                us_timer,
+                neopixel,
+                neopixel_dma,
+            },
+        )
+    }
+
+    #[task(local = [
+        led, us_timer, neopixel, neopixel_dma,
+        framebuffer_0: [Srgb; NUM_PIXELS] = [Srgb::new(0., 0., 0.); NUM_PIXELS],
+        framebuffer_1: [Srgb; NUM_PIXELS] = [Srgb::new(0., 0., 0.); NUM_PIXELS],
+        framebuffer_2: [[u8; 3]; NUM_PIXELS] = [[0; 3]; NUM_PIXELS],
+        buffers: (
+            PreprocessedPixels<NUM_PIXELS, 3>,
+            PreprocessedPixels<NUM_PIXELS, 3>,
+        ) = (PreprocessedPixels::new(), PreprocessedPixels::new())
+    ])]
+    async fn animate(cx: animate::Context) {
+        let animate::LocalResources {
+            led,
+            us_timer,
+            framebuffer_0,
+            framebuffer_1,
+            framebuffer_2,
+            buffers,
+            neopixel,
+            neopixel_dma,
+            ..
+        } = cx.local;
+
+        let time_us = || us_timer.count();
+
+        let mut flip_buffers = false;
+
+        let mut t = 0;
+
+        let mut t_last = time_us() as i32;
+
+        loop {
+            let (render_buffer, display_buffer) = if flip_buffers {
+                (&mut buffers.0, &buffers.1)
+            } else {
+                (&mut buffers.1, &buffers.0)
+            };
+            flip_buffers = !flip_buffers;
+
+            let lagged = neopixel
+                .write_dma(display_buffer, neopixel_dma, 1, async {
+                    t += 1;
+
+                    render_frame(
+                        t,
+                        framebuffer_0,
+                        framebuffer_1,
+                        framebuffer_2,
+                        render_buffer,
+                    );
+
+                    led.toggle();
+
+                    if (t % 100) == 0 {
+                        let t_now = time_us() as i32;
+                        let t_diff = (t_now).wrapping_sub(t_last);
+                        t_last = t_now;
+
+                        let t_diff = (t_diff as f32) / 1_000_000.0;
+                        let fps = 100.0 / t_diff;
+
+                        log::info!("Frames: {}, FPS: {:.02}", t, fps);
+                    }
+                })
+                .await
+                .unwrap()
+                .lagged;
+
+            if lagged {
+                // Note that with the current implementation of this
+                // example, it is expected that the first frame lags.
+                // Reason is that we use double buffering, and while
+                // rendering the first frame, the other buffer will get
+                // displayed, which is empty. And displaying an empty
+                // buffer is really fast.
+                //
+                // This could be fixed by pre-rendering the first frame,
+                // but was left in here intentionally to demonstrate
+                // this feature.
+                log::warn!("Frame {} lagged.", t - 1);
+            }
+        }
+    }
+}

--- a/examples/triple_332_dma_rtic.rs
+++ b/examples/triple_332_dma_rtic.rs
@@ -74,11 +74,11 @@ mod app {
         us_timer: hal::gpt::Gpt1,
         neopixel: WS2812Driver<2, 3, (P6, P7, P8)>,
         neopixel_dma: hal::dma::channel::Channel,
-        neopixel_interrupt_handler: &'static ws2812_flexio::InterruptHandler<2>, // TODO: make reference internal
+        neopixel_interrupt_handler: ws2812_flexio::InterruptHandler<2>,
     }
 
     #[init(local = [
-        interrupt_handler: Option<ws2812_flexio::InterruptHandler<2>> = None
+        ws2812_data: Option<ws2812_flexio::InterruptHandlerData<2>> = None
     ])]
     fn init(cx: init::Context) -> (Shared, Local) {
         let board::Resources {
@@ -136,8 +136,7 @@ mod app {
             FLEXIO2_CLK_PODF: DIVIDE_6,
         );
         let mut neopixel = WS2812Driver::init(flexio2, (pins.p6, pins.p7, pins.p8)).unwrap();
-        let neopixel_interrupt_handler =
-            neopixel.take_interrupt_handler(cx.local.interrupt_handler);
+        let neopixel_interrupt_handler = neopixel.take_interrupt_handler(cx.local.ws2812_data);
         unsafe {
             cortex_m::peripheral::NVIC::unmask(imxrt_ral::interrupt::FLEXIO2);
         }

--- a/examples/triple_332_dma_rtic.rs
+++ b/examples/triple_332_dma_rtic.rs
@@ -177,7 +177,7 @@ mod app {
 
         // Clear LED as fast as possible,
         // to demonstrate that lower priority tasks can still run
-        // without influencing the stability of the ws2812 framerate
+        // without influencing the stability of the WS2812 framerate
         loop {
             led.lock(|led| led.clear());
         }

--- a/examples/triple_332_dma_rtic.rs
+++ b/examples/triple_332_dma_rtic.rs
@@ -1,7 +1,7 @@
 // This example renders a moving rainbow on a 332 pixel long led strip using a Teensy MicroMod.
 //
 // With the help of `RTIC 2` the bus operation happens completely asynchronously.
-// Sadly, this requires some interrupts to be set up properly.
+// Note that this requires some extra interrupts to be set up properly.
 //
 // Led Strip: https://www.ipixelleds.com/index.php?id=923
 // Teensy Micromod: https://www.sparkfun.com/products/16402

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = ["thumbv7em-none-eabihf"]

--- a/src/flexio/dma.rs
+++ b/src/flexio/dma.rs
@@ -2,13 +2,13 @@ use imxrt_hal::dma;
 use imxrt_ral::{flexio, write_reg};
 
 pub(crate) struct WS2812Dma<'a, const N: u8> {
-    flexio: &'a mut flexio::Instance<N>,
+    flexio: &'a flexio::Instance<N>,
     shifter_id: u8,
     dma_channel: u32,
 }
 
 impl<'a, const N: u8> WS2812Dma<'a, N> {
-    pub fn new(flexio: &'a mut flexio::Instance<N>, shifter_id: u8, dma_channel: u32) -> Self {
+    pub fn new(flexio: &'a flexio::Instance<N>, shifter_id: u8, dma_channel: u32) -> Self {
         Self {
             flexio,
             shifter_id,

--- a/src/flexio/driver.rs
+++ b/src/flexio/driver.rs
@@ -184,7 +184,7 @@ where
         imxrt_ral::write_reg!(imxrt_ral::flexio, self.flexio(), TIMIEN, mask);
 
         InterruptHandler {
-            data: self.inner.to_static_ref(storage),
+            data: self.inner.convert_to_static_ref(storage),
         }
     }
 

--- a/src/flexio/driver.rs
+++ b/src/flexio/driver.rs
@@ -173,9 +173,13 @@ where
 
     /// Take the interrupt handler callback from the driver.
     ///
-    /// For the correct functionality of [`write_dma()`](WS2812Driver::write_dma) in
-    /// waker-based async runtimes (like RTIC 2), it is required to invoke the handler
-    /// function every time an interrupt of the given FlexIO peripheral happens.
+    /// # Arguments
+    ///
+    /// * `storage` - Static memory required by the function to work. See [`InterruptHandlerData`] for more information.
+    ///
+    /// For correct functionality of [`write_dma()`](WS2812Driver::write_dma) in
+    /// waker-based async runtimes (like RTIC 2), it is required to invoke the returned
+    /// [`InterruptHandler`] every time an interrupt of the given FlexIO peripheral happens.
     pub fn take_interrupt_handler(
         &mut self,
         storage: &'static mut Option<InterruptHandlerData<N>>,

--- a/src/flexio/driver.rs
+++ b/src/flexio/driver.rs
@@ -287,6 +287,9 @@ where
         };
 
         // Wait for transfer finished
+        while !self.shift_buffer_empty() {
+            self.inner.get().finished_watcher.finished().await;
+        }
         self.inner.get().finished_watcher.finished().await;
 
         Ok(result)

--- a/src/flexio/idle_timer_finished_watcher.rs
+++ b/src/flexio/idle_timer_finished_watcher.rs
@@ -1,0 +1,122 @@
+use core::{
+    cell::RefCell,
+    ops::Deref,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use cortex_m::interrupt::{self, Mutex};
+use futures::Future;
+
+struct IdleTimerFinishedWatcherInner<const N: u8> {
+    happened: bool,
+    waker: Option<Waker>,
+    flexio: imxrt_ral::flexio::Instance<N>,
+}
+
+pub(crate) struct IdleTimerFinishedWatcher<const N: u8> {
+    inner: Mutex<RefCell<IdleTimerFinishedWatcherInner<N>>>,
+    idle_timer_id: u8,
+}
+
+impl<const N: u8> IdleTimerFinishedWatcherInner<N> {
+    pub fn check_and_reset(&mut self, idle_timer_id: u8) {
+        let mask = 1u32 << idle_timer_id;
+        let flag_set = (imxrt_ral::read_reg!(imxrt_ral::flexio, self.flexio, TIMSTAT) & mask) != 0;
+
+        if flag_set {
+            imxrt_ral::write_reg!(imxrt_ral::flexio, self.flexio, TIMSTAT, mask);
+
+            self.happened = true;
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+impl<const N: u8> IdleTimerFinishedWatcher<N> {
+    pub fn new(flexio: &imxrt_ral::flexio::Instance<N>, idle_timer_id: u8) -> Self {
+        Self {
+            inner: Mutex::new(RefCell::new(IdleTimerFinishedWatcherInner {
+                happened: false,
+                waker: None,
+                flexio: unsafe { imxrt_ral::flexio::Instance::<N>::new(flexio.deref()) },
+            })),
+            idle_timer_id,
+        }
+    }
+
+    fn with_check_and_reset<R>(
+        &self,
+        f: impl FnOnce(&mut IdleTimerFinishedWatcherInner<N>) -> R,
+    ) -> R {
+        interrupt::free(|cs| {
+            let inner = self.inner.borrow(cs);
+            let mut inner = inner.borrow_mut();
+            inner.check_and_reset(self.idle_timer_id);
+
+            f(&mut inner)
+        })
+    }
+
+    pub fn on_interrupt(&self) {
+        self.with_check_and_reset(|_| {});
+    }
+
+    pub fn clear(&self) {
+        self.with_check_and_reset(|inner| {
+            inner.happened = false;
+        });
+    }
+
+    pub fn poll(&self) -> bool {
+        self.with_check_and_reset(|inner| inner.happened)
+    }
+
+    pub fn finished(&self) -> IdleTimerFinished<N> {
+        IdleTimerFinished(self)
+    }
+}
+
+pub struct IdleTimerFinished<'a, const N: u8>(&'a IdleTimerFinishedWatcher<N>);
+
+impl<const N: u8> Future for IdleTimerFinished<'_, N> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.0.with_check_and_reset(|inner| {
+            if inner.happened {
+                Poll::Ready(())
+            } else {
+                let new_waker = cx.waker();
+
+                // From embassy
+                // https://github.com/embassy-rs/embassy/blob/b99533607ceed225dd12ae73aaa9a0d969a7365e/embassy-sync/src/waitqueue/waker.rs#L59-L61
+                match &inner.waker {
+                    // Optimization: If both the old and new Wakers wake the same task, we can simply
+                    // keep the old waker, skipping the clone. (In most executor implementations,
+                    // cloning a waker is somewhat expensive, comparable to cloning an Arc).
+                    Some(w2) if (w2.will_wake(new_waker)) => {}
+                    _ => {
+                        // clone the new waker and store it
+                        if let Some(old_waker) = inner.waker.replace(new_waker.clone()) {
+                            // We had a waker registered for another task. Wake it, so the other task can
+                            // reregister itself if it's still interested.
+                            //
+                            // If two tasks are waiting on the same thing concurrently, this will cause them
+                            // to wake each other in a loop fighting over this WakerRegistration. This wastes
+                            // CPU but things will still work.
+                            //
+                            // If the user wants to have two tasks waiting on the same thing they should use
+                            // a more appropriate primitive that can store multiple wakers.
+                            old_waker.wake()
+                        }
+                    }
+                }
+
+                Poll::Pending
+            }
+        })
+    }
+}

--- a/src/flexio/idle_timer_finished_watcher.rs
+++ b/src/flexio/idle_timer_finished_watcher.rs
@@ -1,11 +1,11 @@
 use core::{
     cell::RefCell,
+    future::Future,
     pin::Pin,
     task::{Context, Poll, Waker},
 };
 
 use cortex_m::interrupt::{self, Mutex};
-use futures::Future;
 
 struct IdleTimerFinishedWatcherInner<const N: u8> {
     happened: bool,

--- a/src/flexio/interrupt_handler.rs
+++ b/src/flexio/interrupt_handler.rs
@@ -1,0 +1,8 @@
+use super::InterruptHandler;
+
+impl<const N: u8> InterruptHandler<N> {
+    /// TODO
+    pub fn on_interrupt(&self) {
+        self.watcher.on_interrupt();
+    }
+}

--- a/src/flexio/interrupt_handler.rs
+++ b/src/flexio/interrupt_handler.rs
@@ -3,6 +3,6 @@ use super::InterruptHandler;
 impl<const N: u8> InterruptHandler<N> {
     /// TODO
     pub fn on_interrupt(&self) {
-        self.data.watcher.on_interrupt();
+        self.data.finished_watcher.on_interrupt();
     }
 }

--- a/src/flexio/interrupt_handler.rs
+++ b/src/flexio/interrupt_handler.rs
@@ -1,7 +1,13 @@
 use super::InterruptHandler;
 
 impl<const N: u8> InterruptHandler<N> {
-    /// TODO
+    /// Signals to the [`WS2812Driver`](crate::WS2812Driver) that a FlexIO
+    /// interrupt happened.
+    ///
+    /// Needs to be called inside of the respective FlexIO
+    /// interrupt handler function.
+    ///
+    /// See the [examples](https://github.com/Finomnis/ws2812-flexio/tree/main/examples) for more information.
     pub fn on_interrupt(&self) {
         self.data.finished_watcher.on_interrupt();
     }

--- a/src/flexio/interrupt_handler.rs
+++ b/src/flexio/interrupt_handler.rs
@@ -3,6 +3,6 @@ use super::InterruptHandler;
 impl<const N: u8> InterruptHandler<N> {
     /// TODO
     pub fn on_interrupt(&self) {
-        self.watcher.on_interrupt();
+        self.data.watcher.on_interrupt();
     }
 }

--- a/src/flexio/maybe_own.rs
+++ b/src/flexio/maybe_own.rs
@@ -22,7 +22,7 @@ impl<T: 'static> MaybeOwn<T> {
         }
     }
 
-    pub fn to_static_ref(&mut self, storage: &'static mut Option<T>) -> &'static T {
+    pub fn convert_to_static_ref(&mut self, storage: &'static mut Option<T>) -> &'static T {
         match &mut self.inner {
             MaybeOwnEnum::Owned(x) => {
                 let x = x.take().unwrap();

--- a/src/flexio/maybe_own.rs
+++ b/src/flexio/maybe_own.rs
@@ -1,0 +1,37 @@
+pub struct MaybeOwn<T: 'static> {
+    inner: MaybeOwnEnum<T>,
+}
+
+enum MaybeOwnEnum<T: 'static> {
+    Owned(Option<T>),
+    StaticRef(&'static T),
+}
+
+impl<T: 'static> MaybeOwn<T> {
+    pub fn new(t: T) -> Self {
+        Self {
+            inner: MaybeOwnEnum::Owned(Some(t)),
+        }
+    }
+
+    pub fn get(&self) -> &T {
+        match &self.inner {
+            MaybeOwnEnum::Owned(Some(x)) => x,
+            MaybeOwnEnum::StaticRef(x) => x,
+            MaybeOwnEnum::Owned(None) => unreachable!(),
+        }
+    }
+
+    pub fn to_static_ref(&mut self, storage: &'static mut Option<T>) -> &'static T {
+        match &mut self.inner {
+            MaybeOwnEnum::Owned(x) => {
+                let x = x.take().unwrap();
+                assert!(storage.is_none());
+                let x: &'static T = storage.insert(x);
+                self.inner = MaybeOwnEnum::StaticRef(x);
+                x
+            }
+            MaybeOwnEnum::StaticRef(x) => x,
+        }
+    }
+}

--- a/src/flexio/mod.rs
+++ b/src/flexio/mod.rs
@@ -5,12 +5,17 @@ use ral::{flexio, Valid};
 mod dma;
 mod driver;
 mod flexio_configurator;
+mod idle_timer_finished_watcher;
 mod interleaved_pixels;
+mod interrupt_handler;
+mod maybe_own;
 mod preprocessed_pixels;
 
 use crate::Pins;
 
 pub use preprocessed_pixels::PreprocessedPixels;
+
+use self::{idle_timer_finished_watcher::IdleTimerFinishedWatcher, maybe_own::MaybeOwn};
 
 /// A WS2812 Neopixel LED Strip driver based on the i.MX RT FlexIO module
 pub struct WS2812Driver<const N: u8, const L: usize, PINS: Pins<N, L>>
@@ -19,6 +24,7 @@ where
 {
     flexio: flexio::Instance<N>,
     _pins: PINS,
+    idle_timer_finished: MaybeOwn<InterruptHandler<N>>,
 }
 
 /// The result of [WS2812Driver::write_dma()][WS2812Driver::write_dma].
@@ -28,4 +34,9 @@ pub struct WriteDmaResult<R> {
     /// True if the concurrent function took longer than writing the
     /// data to the LED strips. This might indicate a render lag.
     pub lagged: bool,
+}
+
+/// TODO
+pub struct InterruptHandler<const N: u8> {
+    watcher: IdleTimerFinishedWatcher<N>,
 }

--- a/src/flexio/mod.rs
+++ b/src/flexio/mod.rs
@@ -22,9 +22,8 @@ pub struct WS2812Driver<const N: u8, const L: usize, PINS: Pins<N, L>>
 where
     flexio::Instance<N>: Valid,
 {
-    flexio: flexio::Instance<N>,
     _pins: PINS,
-    idle_timer_finished: MaybeOwn<InterruptHandler<N>>,
+    inner: MaybeOwn<InterruptHandlerData<N>>,
 }
 
 /// The result of [WS2812Driver::write_dma()][WS2812Driver::write_dma].
@@ -37,6 +36,11 @@ pub struct WriteDmaResult<R> {
 }
 
 /// TODO
-pub struct InterruptHandler<const N: u8> {
+pub struct InterruptHandlerData<const N: u8> {
     watcher: IdleTimerFinishedWatcher<N>,
+}
+
+/// TODO
+pub struct InterruptHandler<const N: u8> {
+    data: &'static InterruptHandlerData<N>,
 }

--- a/src/flexio/mod.rs
+++ b/src/flexio/mod.rs
@@ -40,7 +40,9 @@ pub struct WriteDmaResult<R> {
 /// For RTIC 2, it is recommended to have this allocated by the `#[init]` macro, like so:
 ///
 /// ```rust
-/// #[init(local = [ws2812_data: Option<ws2812_flexio::InterruptHandlerData<2>> = None])]
+/// #[init(local = [
+///     ws2812_data: Option<ws2812_flexio::InterruptHandlerData<2>> = None
+/// ])]
 /// fn init(cx: init::Context) -> (Shared, Local) {
 ///     // ...
 /// }

--- a/src/flexio/mod.rs
+++ b/src/flexio/mod.rs
@@ -37,7 +37,7 @@ pub struct WriteDmaResult<R> {
 
 /// TODO
 pub struct InterruptHandlerData<const N: u8> {
-    watcher: IdleTimerFinishedWatcher<N>,
+    finished_watcher: IdleTimerFinishedWatcher<N>,
 }
 
 /// TODO

--- a/src/flexio/mod.rs
+++ b/src/flexio/mod.rs
@@ -35,12 +35,27 @@ pub struct WriteDmaResult<R> {
     pub lagged: bool,
 }
 
-/// TODO
+/// Static memory required by the [`WS2812Driver::take_interrupt_handler`] function.
+///
+/// For RTIC 2, it is recommended to have this allocated by the `#[init]` macro, like so:
+///
+/// ```rust
+/// #[init(local = [ws2812_data: Option<ws2812_flexio::InterruptHandlerData<2>> = None])]
+/// fn init(cx: init::Context) -> (Shared, Local) {
+///     // ...
+/// }
+/// ```
 pub struct InterruptHandlerData<const N: u8> {
     finished_watcher: IdleTimerFinishedWatcher<N>,
 }
 
-/// TODO
+/// An interrupt handler that signals to the driver
+/// that an interrupt happened.
+///
+/// For correct functionality of [`WS2812Driver::write_dma`] in
+/// waker-based async runtimes (like RTIC 2), it is required to invoke the
+/// [`InterruptHandler::on_interrupt`] function every time an interrupt
+/// of the associated FlexIO peripheral happens.
 pub struct InterruptHandler<const N: u8> {
     data: &'static InterruptHandlerData<N>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod pixelstream;
 /// Possible errors that could happen.
 pub mod errors;
 
-pub use flexio::{PreprocessedPixels, WS2812Driver, WriteDmaResult};
+pub use flexio::{InterruptHandler, PreprocessedPixels, WS2812Driver, WriteDmaResult};
 pub use pins::Pins;
 pub use pixel::Pixel;
 pub use pixelstream::IntoPixelStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ mod pixelstream;
 /// Possible errors that could happen.
 pub mod errors;
 
-pub use flexio::{InterruptHandler, PreprocessedPixels, WS2812Driver, WriteDmaResult};
+pub use flexio::{
+    InterruptHandler, InterruptHandlerData, PreprocessedPixels, WS2812Driver, WriteDmaResult,
+};
 pub use pins::Pins;
 pub use pixel::Pixel;
 pub use pixelstream::IntoPixelStream;


### PR DESCRIPTION
Motivation: RTIC 2 is completely `async` based, so implementing something no-blocking would free up a lot of time in between frames.

Before this change, the following problem exists:
- We want the most consistent frame rate. Therefore it is desirable to have the ws2812 thread be the highest priority.
- However, this would mean that nothing else happens, because the current implementation uses busy waiting.

Implementing async would mean that the ws2812 thread **could** actually be the highest priority, and yet it wouldn't block lower-priority tasks during waiting time.